### PR TITLE
Remove superfluous comma, fixing SQL syntax error

### DIFF
--- a/src/api/wishes.php
+++ b/src/api/wishes.php
@@ -318,7 +318,7 @@ switch ($_SERVER['REQUEST_METHOD']) {
              */
             $database->query(
                 'UPDATE `wishes`
-                    SET `url` = :wish_url_proposed,
+                    SET `url` = :wish_url_proposed
                   WHERE `url` = :wish_url_current',
                 array(
                     'wish_url_proposed' => Sanitiser::getURL($_PUT['wish_url_proposed']),


### PR DESCRIPTION
Hi there! First off, thanks for this great app!

I removed an incorrect comma in the SQL for updating the wish URL, which previously caused an Internal Server Error due to a syntax error.