### PR TITLE
FIX: Allow wishes without host/URL set.

### DIFF
--- a/src/classes/wishthis/Wish.php
+++ b/src/classes/wishthis/Wish.php
@@ -105,9 +105,12 @@ class Wish
             $urlParameters = [];
         }
 
-        foreach (self::$affiliates as $host => $tagId) {
-            if (\str_contains($urlParts['host'], $host) && isset($urlParameters['tag'])) {
-                return true;
+        // FIX: Allow wishes without host/URL set.
+        if (isset($urlParts['host'])) {
+            foreach (self::$affiliates as $host => $tagId) {
+                if (\str_contains($urlParts['host'], $host) && isset($urlParameters['tag'])) {
+                    return true;
+                }
             }
         }
 


### PR DESCRIPTION
Whenever you save a wish without an URL address and later on try to edit it, you will be greeted with plethora XHR-fetched errors. Once you rid of them and simply click on the URL field, then click away - those errors will be thrown at you again.
![wishthis errors](https://maciej.taranienko.pl/wishthis-errors.png)

**This PR aims to fix that issue.**