### PR TITLE
fix: Use mb_ string operations in planet captcha

### DIFF
--- a/src/pages/register.php
+++ b/src/pages/register.php
@@ -32,21 +32,21 @@ if (isset($_POST['email'], $_POST['password']) && !empty($_POST['planet']) && !$
     $user_email = Sanitiser::getEmail($_POST['email']);
 
     $isHuman     = false;
-    $planet      = strtolower(Sanitiser::getTitle($_POST['planet']));
-    $planetName  = strtoupper($planet[0]) . substr($planet, 1);
+    $planet      = mb_strtolower($_POST['planet']);
+    $planetName  = mb_strtoupper($planet[0]) . substr($planet, 1);
     $planets     = [
-        strtolower(__('Mercury')),
-        strtolower(__('Venus')),
-        strtolower(__('Earth')),
-        strtolower(__('Mars')),
-        strtolower(__('Jupiter')),
-        strtolower(__('Saturn')),
-        strtolower(__('Uranus')),
-        strtolower(__('Neptune')),
+        mb_strtolower(__('Mercury')),
+        mb_strtolower(__('Venus')),
+        mb_strtolower(__('Earth')),
+        mb_strtolower(__('Mars')),
+        mb_strtolower(__('Jupiter')),
+        mb_strtolower(__('Saturn')),
+        mb_strtolower(__('Uranus')),
+        mb_strtolower(__('Neptune')),
     ];
     $not_planets = [
-        strtolower(__('Pluto')),
-        strtolower(__('Sun')),
+        mb_strtolower(__('Pluto')),
+        mb_strtolower(__('Sun')),
     ];
 
     if (in_array($planet, array_merge($planets, $not_planets))) {

--- a/src/pages/register.php
+++ b/src/pages/register.php
@@ -33,7 +33,7 @@ if (isset($_POST['email'], $_POST['password']) && !empty($_POST['planet']) && !$
 
     $isHuman     = false;
     $planet      = mb_strtolower($_POST['planet']);
-    $planetName  = mb_strtoupper($planet[0]) . substr($planet, 1);
+    $planetName  = mb_strtoupper(mb_substr($planet, 0, 1)) . mb_substr($planet, 1);
     $planets     = [
         mb_strtolower(__('Mercury')),
         mb_strtolower(__('Venus')),

--- a/src/pages/register.php
+++ b/src/pages/register.php
@@ -33,7 +33,7 @@ if (isset($_POST['email'], $_POST['password']) && !empty($_POST['planet']) && !$
 
     $isHuman     = false;
     $planet      = mb_strtolower($_POST['planet']);
-    $planetName  = mb_strtoupper(mb_substr($planet, 0, 1)) . mb_substr($planet, 1);
+    $planetName  = Sanitiser::sanitiseText(mb_strtoupper(mb_substr($planet, 0, 1)) . mb_substr($planet, 1));
     $planets     = [
         mb_strtolower(__('Mercury')),
         mb_strtolower(__('Venus')),


### PR DESCRIPTION
Hi!

A user using their browser in Ukrainian reported issues registering an account, with the site not accepting "Марс" (Mars) as an answer to the question for a planet in our solar system.

The issue seems to consist of two parts – first, the Ukrainian translations of some planet names included periods at the end. I have fixed that on Transifex, see #211.

But also the comparison itself had some problems with multi-byte characters from non-Latin scripts. I have replaced the `strtolower` and `strtoupper` functions with their `mb_`-prefixed versions to ensure they work properly.

~~I also removed a `Sanitiser::getTitle` call on the input – since we are only comparing strings and not trusting the input for anything else, sanitization shouldn't be necessary here, and if we run it on the input, we would also have to run it on the accepted responses, so throwing it out altogether was the easier option.~~ I re-added sanitization for the variable used in the error message when you enter an incorrect answer. I suppose that's what is was meant for.