### PR TITLE
[WIP] Add optional image download from URL instead of saving as reference

### DIFF
--- a/src/config/config-sample.php
+++ b/src/config/config-sample.php
@@ -55,6 +55,15 @@ namespace wishthis;
 \define('PLAUSIBLE', false);
 
 /**
+ * Image Download from URL
+ *
+ * Allows fetching external images and storing them locally.
+ */
+\define('UPLOAD_ENABLED', true);
+\define('UPLOAD_MAX_SIZE', 2 * 1024 * 1024);
+\define('UPLOAD_ALLOWED_TYPES', ['image/jpeg', 'image/png', 'image/webp']);
+
+/**
  * Miscellaneous
  */
 \define('DISABLE_USER_REGISTRATION', false);

--- a/src/pages/parts/wish-add.php
+++ b/src/pages/parts/wish-add.php
@@ -76,6 +76,29 @@ namespace wishthis;
                     />
                 </div>
 
+                <?php if (\defined('UPLOAD_ENABLED') && UPLOAD_ENABLED): ?>
+                    <div class="field image-mode-options">
+                        <label><?= __('Image Handling') ?></label>
+                        <div class="ui radio image-mode-url">
+                            <input type="radio"
+                                id="image_mode_url"
+                                name="wish_image_mode"
+                                value="url"
+                                checked
+                            />
+                            <label for="image_mode_url"><?= __('Save as URL (default)') ?></label>
+                        </div>
+                        <div class="ui radio image-mode-download">
+                            <input type="radio"
+                                id="image_mode_download"
+                                name="wish_image_mode"
+                                value="download"
+                            />
+                            <label for="image_mode_download"><?= __('Download and store locally') ?></label>
+                        </div>
+                    </div>
+                <?php endif; ?>
+
                 <div class="grouped fields">
                     <label><?= __('Properties') ?></label>
 


### PR DESCRIPTION
This is a work in progress PR for the image handling feature we discussed in #223 .
So far:

-     Added config options to enable/disable image downloading
-     Updated frontend to allow user choice between URL and local image storage

Still to do:

-     Implement backend handling for downloading and storing images
-     Add server-side validation and error handling

Note: I had some minor struggles with Semantic UI’s checkbox behavior interfering with tabs, so I opted to use plain radio buttons without .checkbox styling for now. Feedback welcome if there’s a preferred way to handle this.

Feedback is very welcome at this stage!